### PR TITLE
additional fixes for api commons

### DIFF
--- a/api_commons/common.py
+++ b/api_commons/common.py
@@ -37,7 +37,7 @@ from rest_framework.exceptions import NotAuthenticated, AuthenticationFailed, Me
 from rest_framework.renderers import JSONRenderer
 from rest_framework.response import Response
 from rest_framework.settings import api_settings
-from rest_framework.status import is_client_error, HTTP_400_BAD_REQUEST
+from rest_framework.status import is_client_error, HTTP_400_BAD_REQUEST, HTTP_401_UNAUTHORIZED
 from rest_framework.views import APIView
 
 from .dto import BaseDto, ApiResponseDto
@@ -95,6 +95,7 @@ class ApiResponse(Response):
         else:
             message = "Unauthorized"
         response.data.service.error_message = message
+        response.data.service.error_code = HTTP_401_UNAUTHORIZED  # service error code shouldn't be zero value
         return response
 
     @classmethod

--- a/api_commons/common.py
+++ b/api_commons/common.py
@@ -24,11 +24,10 @@
 import collections
 import logging
 import sys
-from json import JSONEncoder
 from typing import Union
-from uuid import UUID
 
 from django.core.exceptions import ObjectDoesNotExist
+from django.core.serializers.json import DjangoJSONEncoder
 from django.http import HttpRequest
 from django.http import HttpResponse
 from rest_framework import status as HttpStatus
@@ -146,12 +145,10 @@ class ApiResponse(Response):
         )
 
 
-class JsonEncoder(JSONEncoder):
+class JsonEncoder(DjangoJSONEncoder):
     def default(self, o):
         if isinstance(o, BaseDto):
             return o.to_dict()
-        if isinstance(o, UUID):
-            return str(o)
         return super().default(o)
 
 

--- a/api_commons/common.py
+++ b/api_commons/common.py
@@ -33,13 +33,15 @@ from django.http import HttpRequest
 from django.http import HttpResponse
 from rest_framework import status as HttpStatus
 from rest_framework.authentication import SessionAuthentication, BasicAuthentication
-from rest_framework.exceptions import NotAuthenticated, AuthenticationFailed, MethodNotAllowed
+from rest_framework.exceptions import NotAuthenticated, AuthenticationFailed, MethodNotAllowed, UnsupportedMediaType, \
+    ParseError
 from rest_framework.renderers import JSONRenderer
 from rest_framework.response import Response
 from rest_framework.settings import api_settings
-from rest_framework.status import is_client_error, HTTP_400_BAD_REQUEST, HTTP_401_UNAUTHORIZED
+from rest_framework.status import is_client_error, HTTP_400_BAD_REQUEST, HTTP_401_UNAUTHORIZED, \
+    HTTP_405_METHOD_NOT_ALLOWED, HTTP_403_FORBIDDEN
 from rest_framework.views import APIView
-
+from django.utils.translation import ugettext_lazy as _
 from .dto import BaseDto, ApiResponseDto
 from .error import InvalidPaginationOptionsError, InvalidInputDataError, ErrorCode
 
@@ -126,6 +128,23 @@ class ApiResponse(Response):
         response.data.service.error_code = HttpStatus.HTTP_500_INTERNAL_SERVER_ERROR
         return response
 
+    @classmethod
+    def not_allowed(cls):
+        return cls.client_error(
+            HTTP_405_METHOD_NOT_ALLOWED,
+            "HTTP Method Not allowed.",
+            HTTP_405_METHOD_NOT_ALLOWED,
+            None
+        )
+
+    @classmethod
+    def forbidden(cls):
+        return cls.client_error(
+            HTTP_403_FORBIDDEN,
+            "Forbidden",
+            HTTP_403_FORBIDDEN
+        )
+
 
 class JsonEncoder(JSONEncoder):
     def default(self, o):
@@ -206,13 +225,18 @@ def exception_handler(exc: Exception, context):
     if isinstance(exc, (NotAuthenticated, AuthenticationFailed)):
         return ApiResponse.not_authenticated()
     if isinstance(exc, ObjectDoesNotExist):
-        return ApiResponse.not_found(exc)
+        return ApiResponse.not_found(str(exc))
     if isinstance(exc, InvalidInputDataError):
         return ApiResponse.bad_request(str(exc))
-    if isinstance(exc, MethodNotAllowed):
-        return ApiResponse.client_error(HttpStatus.HTTP_405_METHOD_NOT_ALLOWED, ErrorCode(None, 'Method Not Allowed'))
-    logger.exception(str(exc))
-    return ApiResponse.internal_server_error(exc)
+    elif isinstance(exc, MethodNotAllowed):
+        return ApiResponse.not_allowed()
+    elif isinstance(exc, UnsupportedMediaType):
+        return ApiResponse.bad_request(str(exc))
+    elif isinstance(exc, ParseError):
+        return ApiResponse.bad_request(_("Json is invalid."))
+    else:
+        logger.exception(str(exc))
+        return ApiResponse.internal_server_error(exc)
 
 
 def __set_response_attributes(response: HttpResponse):

--- a/api_commons/dto.py
+++ b/api_commons/dto.py
@@ -106,10 +106,11 @@ class ApiResponseDto(BaseDto):
 
 
 class RelatedDtoField(Field):
-    def __init__(self, dto_class, required: bool = None, default=empty, initial=empty) -> None:
+    def __init__(self, dto_class, required: bool = None, allow_null=False, default=empty, initial=empty) -> None:
         super().__init__(read_only=False, write_only=False, source=None, required=required, default=default,
                          initial=initial,
-                         label=None, help_text=None, style=None, error_messages=None, validators=None, allow_null=False)
+                         label=None, help_text=None, style=None, error_messages=None, validators=None,
+                         allow_null=allow_null)
         self.dto_class = dto_class
 
     def to_representation(self, instance: BaseDto):


### PR DESCRIPTION
change log:

- extended exception handler with ParseError and UnsupportedMediaType errors
- added two error methods (403 and 405) to ApiResponse class
- fixed 401 error response, it returned 0 in error_code previously (shouldn't be a zero because it's not successful response)
- fixed subclassing JsonEncoder class - it should be subclassed from DjangoJsonEncoder instead (date, datetime, decimal, UUID serialization support)
- RelatedDtoField should respect allow_null parameter
